### PR TITLE
GHC 9.10 compatibility

### DIFF
--- a/src/Z80/Assembler.hs
+++ b/src/Z80/Assembler.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 
 module Z80.Assembler
@@ -25,8 +28,10 @@ import Data.ByteString (ByteString)
 import Control.Monad.RWS
 import Data.Maybe
 
+#if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
 import Data.Traversable (traverse)
+#endif
 import Prelude
 
 import Z80.Operands

--- a/src/Z80/Assembler.hs
+++ b/src/Z80/Assembler.hs
@@ -25,6 +25,7 @@ import Data.Word
 import qualified Data.ByteString as BS
 import Data.ByteString (ByteString)
 
+import Control.Monad.Fix (MonadFix(..))
 import Control.Monad.RWS
 import Data.Maybe
 

--- a/src/Z80/Operations.hs
+++ b/src/Z80/Operations.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE IncoherentInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 
 module Z80.Operations
@@ -107,7 +108,9 @@ import Data.Word
 import Z80.Assembler
 import Z80.Operands
 
+#if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>))
+#endif
 import Control.Monad       ((>=>))
 import Prelude hiding      (and, or)
 

--- a/src/Z80/Operations.hs
+++ b/src/Z80/Operations.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE IncoherentInstances #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/z80.cabal
+++ b/z80.cabal
@@ -19,7 +19,7 @@ library
                        Z80.Operands,
                        Z80.Operands.LowerCase,
                        Z80.Macros
-  build-depends:       base >=4.7 && <4.9,
+  build-depends:       base >=4.7,
                        bytestring,
                        mtl
   hs-source-dirs:      src
@@ -29,7 +29,7 @@ library
 test-suite tests
   type:                exitcode-stdio-1.0
   main-is:             tests.hs
-  build-depends:       base >=4.7 && <4.9,
+  build-depends:       base >=4.7,
                        bytestring,
                        mtl,
                        HUnit,


### PR DESCRIPTION
- **Avoid spurious warning if `Prelude` already re-exports `(<$>)`**
- **GHC 9.4 compatibility**
- **GHC 9.10 compatibility**
